### PR TITLE
Feat/bjw/seq 컬럼카드 이동 기능

### DIFF
--- a/src/components/view/KanbanBoardCompo.vue
+++ b/src/components/view/KanbanBoardCompo.vue
@@ -95,11 +95,12 @@
               :disabled="isCardOpen"
             >
               <template #item="{ element: col }">
-                <div class="column" :key="col.kanbanColumnId">
+                <div class="column kanban-column" :key="col.kanbanColumnId" :data-column-id="col.kanbanColumnId">
                   <kanban-column
                     :id="col.kanbanColumnId"
                     :title="col.kanbanColumnName"
                     :cards="filteredCardsByColumn(col.kanbanColumnId)"
+                    :columnId="col.kanbanColumnId"
                     :isCardOpen="isCardOpen"
                     @card-move="onCardMove"
                     @open-card="openCard"
@@ -379,24 +380,15 @@ export default {
 
     // 칸반 카드 이동 시
     const onCardMove = (event) => {
-      const { oldIndex, newIndex, element } = event;
-
-      if (!element) {
-        console.error('Error: moved card data is undefined.');
-        return;
-      }
-
-      const movedCard = element;
-
-      // 카드가 정상적으로 이동된 경우에만 처리
-      if (movedCard && movedCard.columnId !== undefined) {
-        // 카드의 이동을 반영
-        kanbanCardStore.moveCard(movedCard.columnId, movedCard.columnId, movedCard.id);
-
-        // 필요 시 서버에 카드 이동 사항을 업데이트할 수 있습니다.
-        console.log(`Card moved from position ${oldIndex} to ${newIndex}`, movedCard);
-      } else {
-        console.error('Error: Moved card is invalid or missing columnId.');
+      const { oldIndex, newIndex, columnId, cardId, fromColumnId, toColumnId } = event;
+      if (fromColumnId && toColumnId && fromColumnId !== toColumnId) {
+        // 컬럼 간 카드 이동 처리
+        console.log(`Card ${cardId} moved from column ${fromColumnId} to column ${toColumnId}`);
+        kanbanCardStore.moveCardToAnotherColumn(cardId, fromColumnId, toColumnId, newIndex);
+      } else if (columnId) {
+        // 같은 컬럼 내 카드 이동 처리
+        console.log(`Card moved in column ${columnId} from ${oldIndex} to ${newIndex}`);
+        kanbanCardStore.moveCardWithinColumn(columnId, oldIndex, newIndex);
       }
     };
 

--- a/src/components/view/KanbanCardCompo.vue
+++ b/src/components/view/KanbanCardCompo.vue
@@ -38,16 +38,16 @@ export default {
       let backgroundColor;
       let color = '#000000'; // 기본 텍스트 색상
       switch (props.card.priority) {
-        case '3': // 낮음
+        case 3: // 낮음
           backgroundColor = '#9BF09B';
           break;
-        case '2': // 중간
+        case 2: // 중간
           backgroundColor = '#9BB8F0';
           break;
-        case '1': // 높음
+        case 1: // 높음
           backgroundColor = '#E99BF0';
           break;
-        case '0': // 긴급
+        case 0: // 긴급
           backgroundColor = '#E45959';
           color = '#ffffff'; // 긴급일 때 흰색 텍스트
           break;
@@ -59,13 +59,13 @@ export default {
 
     const priorityText = computed(() => {
       switch (props.card.priority) {
-        case '3':
+        case 3:
           return '낮음';
-        case '2':
+        case 2:
           return '중간';
-        case '1':
+        case 1:
           return '높음';
-        case '0':
+        case 0:
           return '긴급';
         default:
           return '알 수 없음';
@@ -76,16 +76,16 @@ export default {
     const taskSizeStyle = computed(() => {
       let backgroundColor;
       switch (props.card.taskSize) {
-        case '0': // Small
+        case 0: // Small
           backgroundColor = '#CEF2CE';
           break;
-        case '1': // Medium
+        case 1: // Medium
           backgroundColor = '#CEE0F2';
           break;
-        case '2': // Large
+        case 2: // Large
           backgroundColor = '#E0CEF2';
           break;
-        case '3': // Extra Large
+        case 3: // Extra Large
           backgroundColor = '#F2CECE';
           break;
         default:
@@ -96,13 +96,13 @@ export default {
 
     const taskSizeText = computed(() => {
       switch (props.card.taskSize) {
-        case '0':
+        case 0:
           return 'Small';
-        case '1':
+        case 1:
           return 'Medium';
-        case '2':
+        case 2:
           return 'Large';
-        case '3':
+        case 3:
           return 'Extra Large';
         default:
           return 'Unknown';

--- a/src/components/view/KanbanColumnCompo.vue
+++ b/src/components/view/KanbanColumnCompo.vue
@@ -31,14 +31,12 @@
 </template>
 
 <script>
-// import { useNavigationStore } from '@/stores/navigationStore';
-// import { useRouter } from 'vue-router';
 import { useKanbanCardStore } from '@/stores/kanbanCardStore';
 import { computed, nextTick, ref } from 'vue';
 import draggable from 'vuedraggable';
 import KanbanCard from './KanbanCardCompo.vue';
 import KanbanCardOpen from './KanbanCardOpenCompo.vue';
-import { useWebSocketStore } from '@/stores/webSocketStore';
+// import { useWebSocketStore } from '@/stores/webSocketStore';
 
 export default {
   components: {
@@ -64,15 +62,15 @@ export default {
       type: String,
       default: '#6b9e9b',
     },
+    columnId: {
+      type: String,
+      default: null,
+    },
   },
   emits: ['open-card', 'close-card', 'card-move'],
   setup(props, { emit }) {
     const kanbanCardStore = useKanbanCardStore();
-    // const router = useRouter();
-    // const navigationStore = useNavigationStore();
 
-    const localCards = [...props.cards];
-    // const localCards = ref([...props.cards]);
     // props.cards를 참조하는 computed 속성 사용
     const computedCards = computed(() => {
       return props.cards;
@@ -90,13 +88,6 @@ export default {
     const selectedCard = ref(null); // 선택한 카드
 
     const openKanbanCard = (card) => {
-      // console.log(`칸반카드ID: ${card.id}`);
-      // console.log(`칸반카드: ${card}`);
-      // navigationStore.setActiveItem('kanban');
-      // router.push({
-      //   name: 'KanbanCardCompo',
-      //   query: { id: card.id, title: card.title },
-      // });
       console.log(card);
 
       selectedCard.value = card;
@@ -135,7 +126,6 @@ export default {
           members: [],
         };
         kanbanCardStore.addCard(props.id, newCard.title); // 수정된 부분
-        localCards.value.push(newCard);
         newCardTitle.value = '';
         isCardAdd.value = false;
       }
@@ -143,56 +133,31 @@ export default {
 
     const onCardDrop = async (event) => {
       // async를 추가하여 비동기 함수로 선언
-      const { oldIndex, newIndex } = event;
-      const movedCard = localCards.value[oldIndex];
+      const { from, to, oldIndex, newIndex, item } = event;
 
-      if (oldIndex !== newIndex) {
-        // 로컬에서 카드 순서 변경
-        localCards.value.splice(oldIndex, 1);
-        localCards.value.splice(newIndex, 0, movedCard);
+      console.log('onCardDrop event:', event); // 이벤트 로그 출력
 
-        // WebSocket을 통해 서버로 카드 이동 정보를 전송
-        const message = {
-          projectId: props.id, // 현재 프로젝트 ID
-          cardId: movedCard.id, // 이동된 카드 ID
-          fromIndex: oldIndex, // 이동 전 위치
-          toIndex: newIndex, // 이동 후 위치
-          type: 'CARD_MOVE',
-        };
-        console.log('Card move message:', message); // 메시지 전송 전에 로그 출력
-        // WebSocket 스토어를 통해 메시지 전송
-        const webSocketStore = useWebSocketStore(); // WebSocket Store 사용
-        webSocketStore.sendMessageToProject(message); // 메시지 전송 함수 호출
-        // try {
-        //   // 서버에 순서 변경 요청 보내기 (비동기 작업)
-        //   await axiosInstance.put('/api/kanban-cards/order', {  // await로 비동기 작업 완료 대기
-        //     cardId: movedCard.id,
-        //     oldIndex: oldIndex,
-        //     newIndex: newIndex,
-        //   });
-        //   console.log('서버에 카드 순서가 성공적으로 업데이트되었습니다.');
-        // } catch (error) {
-        //   console.error('카드 순서 업데이트 실패:', error);
-        //   // 오류 발생 시, 원래 상태로 복구
-        //   localCards.value.splice(newIndex, 1);
-        //   localCards.value.splice(oldIndex, 0, movedCard);
-        // }
-        emit('card-move', props.id, props.id, movedCard.id);
+      // 같은 컬럼 내에서 카드 이동
+      if (from === to && oldIndex !== newIndex) {
+        emit('card-move', { oldIndex, newIndex, columnId: props.id });
+      }
+      // 다른 컬럼으로 카드 이동
+      else if (from !== to) {
+        const fromColumnId = props.columnId; // 현재 컬럼의 ID를 사용
 
-        // const id = props.id;
-        // console.log(id);
+        // `to` 요소의 상위 `.column` 요소에서 `data-column-id` 속성을 가져옴
+        const toColumnElement = to.closest('.column'); // `.column`으로 부모 요소를 찾음
+        const toColumnId = toColumnElement?.dataset?.columnId; // `data-column-id` 접근
 
-        // const toColumnId = event.to.closest('.column').dataset.columnId; // 이동 후 컬럼 ID
-        // console.log('to Column ID:', toColumnId);
+        if (!toColumnId) {
+          console.error('Cannot determine toColumnId from dataset.');
+          return;
+        }
 
-        // const fromIndex = event.oldIndex; // 드래그 시작 위치
-        // const toIndex = event.newIndex; // 드롭 위치
-        // console.log(fromIndex);
-        // console.log(toIndex);
-        // console.log('카드 드래그 앤 드롭', event);
-        // const form = { kanbanColumnId: toColumnId, cardSeq: toIndex };
+        const cardId = item.dataset.cardId; // 이동된 카드 ID
 
-        // cardDragAndDrop(form);
+        // 컬럼 간 카드 이동 이벤트를 상위 컴포넌트로 전송
+        emit('card-move', { cardId, fromColumnId, toColumnId, oldIndex, newIndex });
       }
     };
 
@@ -200,7 +165,6 @@ export default {
       isKanbanCardOpen,
       selectedCard,
       closeKanbanCard,
-      localCards,
       newCardTitle,
       isCardAdd,
       startEditing,

--- a/src/components/view/KanbanColumnCompo.vue
+++ b/src/components/view/KanbanColumnCompo.vue
@@ -32,7 +32,7 @@
 
 <script>
 import { useKanbanCardStore } from '@/stores/kanbanCardStore';
-import { computed, nextTick, ref } from 'vue';
+import {computed, nextTick, onMounted, ref} from 'vue';
 import draggable from 'vuedraggable';
 import KanbanCard from './KanbanCardCompo.vue';
 import KanbanCardOpen from './KanbanCardOpenCompo.vue';
@@ -72,9 +72,12 @@ export default {
     const kanbanCardStore = useKanbanCardStore();
 
     // props.cards를 참조하는 computed 속성 사용
-    const computedCards = computed(() => {
-      return props.cards;
+    const computedCards = ref([]);
+    // 컴포넌트가 마운트될 때 스토어에서 카드 데이터를 가져옴
+    onMounted(() => {
+      computedCards.value = kanbanCardStore.getCardsByColumnId(props.columnId);
     });
+    // const computedCards = kanbanCardStore.cards;
     const newCardTitle = ref('');
     const isCardAdd = ref(false);
     const cardInput = ref(null);
@@ -140,6 +143,7 @@ export default {
       // 같은 컬럼 내에서 카드 이동
       if (from === to && oldIndex !== newIndex) {
         emit('card-move', { oldIndex, newIndex, columnId: props.id });
+        computedCards.value = kanbanCardStore.getCardsByColumnId(props.columnId);
       }
       // 다른 컬럼으로 카드 이동
       else if (from !== to) {

--- a/src/stores/kanbanCardStore.js
+++ b/src/stores/kanbanCardStore.js
@@ -108,16 +108,16 @@ export const useKanbanCardStore = defineStore('kanbanCard', () => {
 
   // 컬럼 이동 시 호출하는 함수 columnId 업데이트
   const updateCardsByColumnId = (oldColumnId, newColumnId) => {
-    cards.value.forEach(card => {
-      if(card.columnId === oldColumnId) {
+    cards.value.forEach((card) => {
+      if (card.columnId === oldColumnId) {
         card.columnId = newColumnId;
       }
-    })
+    });
   };
 
   // 같은 컬럼 내에서의 카드 이동
   const moveCardWithinColumn = (columnId, oldIndex, newIndex) => {
-    const columnCards = cards.value.filter(card => card.columnId === columnId);
+    const columnCards = cards.value.filter((card) => card.columnId === columnId);
     const movedCard = columnCards.splice(oldIndex, 1)[0];
     columnCards.splice(newIndex, 0, movedCard);
 
@@ -125,19 +125,31 @@ export const useKanbanCardStore = defineStore('kanbanCard', () => {
     columnCards.forEach((card, index) => {
       card.sequence = index + 1; // 카드 시퀀스 업데이트
     });
+    // 전체 cards 배열에서 해당 컬럼의 카드 시퀀스 업데이트
+    cards.value = cards.value.map((card) => {
+      if (card.columnId === columnId) {
+        const updatedCard = columnCards.find((c) => c.id === card.id);
+        return updatedCard ? { ...card, sequence: updatedCard.sequence } : card;
+      }
+      return card;
+    });
+
+    // cards 배열을 시퀀스에 따라 정렬
+    cards.value.sort((a, b) => a.sequence - b.sequence);
 
     console.log(`Moved card within column ${columnId} from ${oldIndex} to ${newIndex}`);
+    
   };
 
   // 다른 컬럼으로의 카드 이동
   const moveCardToAnotherColumn = (cardId, fromColumnId, toColumnId, newIndex) => {
-    const cardIndex = cards.value.findIndex(card => card.id === cardId && card.columnId === fromColumnId);
+    const cardIndex = cards.value.findIndex((card) => card.id === cardId && card.columnId === fromColumnId);
     if (cardIndex !== -1) {
       const [movedCard] = cards.value.splice(cardIndex, 1);
       movedCard.columnId = toColumnId; // 컬럼 ID 업데이트
 
       // 새로운 컬럼의 위치에 카드 삽입
-      const toColumnCards = cards.value.filter(card => card.columnId === toColumnId);
+      const toColumnCards = cards.value.filter((card) => card.columnId === toColumnId);
       toColumnCards.splice(newIndex, 0, movedCard);
 
       // 시퀀스 업데이트
@@ -149,5 +161,14 @@ export const useKanbanCardStore = defineStore('kanbanCard', () => {
     }
   };
 
-  return { cards, loadAllCards, loadCardDetails, getCardsByColumnId, updateKanbanCardTitle, updateCardsByColumnId, moveCardWithinColumn, moveCardToAnotherColumn };
+  return {
+    cards,
+    loadAllCards,
+    loadCardDetails,
+    getCardsByColumnId,
+    updateKanbanCardTitle,
+    updateCardsByColumnId,
+    moveCardWithinColumn,
+    moveCardToAnotherColumn,
+  };
 });

--- a/src/stores/kanbanCardStore.js
+++ b/src/stores/kanbanCardStore.js
@@ -84,20 +84,6 @@ export const useKanbanCardStore = defineStore('kanbanCard', () => {
     return cards.value.filter((card) => card.columnId === columnId);
   };
 
-  // 칸반 컬럼 움직임에 따른 카드 움직임
-  const updateCardsForMovedColumn = (updatedColumns) => {
-    // 각 컬럼의 새로운 인덱스와 함께 카드 업데이트
-    updatedColumns.forEach((column) => {
-      cards.value.forEach((card) => {
-        if (card.columnId === column.id) {
-          // 카드의 columnId를 업데이트된 컬럼의 인덱스로 설정
-          card.columnId = column.id;
-          console.log(`Updated Card ID: ${card.id} to Column ID: ${card.columnId}`);
-        }
-      });
-    });
-  };
-
   // 칸반 카드 제목 수정
   const updateKanbanCardTitle = async (cardId, updateColumn, updateData) => {
     try {
@@ -127,6 +113,41 @@ export const useKanbanCardStore = defineStore('kanbanCard', () => {
         card.columnId = newColumnId;
       }
     })
-  }
-  return { cards, loadAllCards, loadCardDetails, getCardsByColumnId, updateCardsForMovedColumn, updateKanbanCardTitle, updateCardsByColumnId };
+  };
+
+  // 같은 컬럼 내에서의 카드 이동
+  const moveCardWithinColumn = (columnId, oldIndex, newIndex) => {
+    const columnCards = cards.value.filter(card => card.columnId === columnId);
+    const movedCard = columnCards.splice(oldIndex, 1)[0];
+    columnCards.splice(newIndex, 0, movedCard);
+
+    // 시퀀스 업데이트
+    columnCards.forEach((card, index) => {
+      card.sequence = index + 1; // 카드 시퀀스 업데이트
+    });
+
+    console.log(`Moved card within column ${columnId} from ${oldIndex} to ${newIndex}`);
+  };
+
+  // 다른 컬럼으로의 카드 이동
+  const moveCardToAnotherColumn = (cardId, fromColumnId, toColumnId, newIndex) => {
+    const cardIndex = cards.value.findIndex(card => card.id === cardId && card.columnId === fromColumnId);
+    if (cardIndex !== -1) {
+      const [movedCard] = cards.value.splice(cardIndex, 1);
+      movedCard.columnId = toColumnId; // 컬럼 ID 업데이트
+
+      // 새로운 컬럼의 위치에 카드 삽입
+      const toColumnCards = cards.value.filter(card => card.columnId === toColumnId);
+      toColumnCards.splice(newIndex, 0, movedCard);
+
+      // 시퀀스 업데이트
+      toColumnCards.forEach((card, index) => {
+        card.sequence = index + 1; // 카드 시퀀스 업데이트
+      });
+
+      console.log(`Moved card ${cardId} from column ${fromColumnId} to column ${toColumnId} at position ${newIndex}`);
+    }
+  };
+
+  return { cards, loadAllCards, loadCardDetails, getCardsByColumnId, updateKanbanCardTitle, updateCardsByColumnId, moveCardWithinColumn, moveCardToAnotherColumn };
 });

--- a/src/stores/kanbanColumnStore.js
+++ b/src/stores/kanbanColumnStore.js
@@ -63,16 +63,12 @@ export const useKanbanColumnStore = defineStore('kanbanColumn', () => {
     sortColumns();
     // TODO: 변경된 컬럼을 서버에 저장하거나 필요한 작업
 
-    updateCardsForMovedColumn();
   };
   // 컬럼 순서대로 정렬
   const sortColumns = () => {
     columns.value.sort((a, b) => a.sequence - b.sequence);
   };
 
-  const updateCardsForMovedColumn = () => {
-    kanbanCardStore.updateCardsForMovedColumn(columns.value);
-  };
 
   return {
     columns,


### PR DESCRIPTION
### 변경사항

<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
컬럼 카드가 안열리는 에러와 카드 이동 시 화면 상 움직이지 않던 오류 수정
**TO-BE**
반응형으로 변경 후 데이터를 스토어에서 참조한다.
카드 데이터를 상위 콤포에서 넘기는 것을 컬럼 아이디만 넘기고 아이디 기준으로 스토어 조회
카드 컬럼 간 이동 시 상위 컴포턴트 컬럼의 위치를 인식 못하던 부분 해결
### 테스트

<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->

- [ ]  테스트 코드
- [ ]  API 테스트
